### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,6 +2,8 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on merge
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/F88/tsv2mdt/security/code-scanning/4](https://github.com/F88/tsv2mdt/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file. The best place is at the top level (just after the `name` and before `on`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is likely `contents: read`, as the workflow checks out code and deploys using a service account (not the `GITHUB_TOKEN`). No other permissions appear necessary. The change involves inserting the following lines after the `name` field:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
