### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs-ci-npm.yml
+++ b/.github/workflows/nodejs-ci-npm.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI (npm)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/F88/tsv2mdt/security/code-scanning/2](https://github.com/F88/tsv2mdt/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or to the specific job(s) that limits the GITHUB_TOKEN permissions to the minimum required. In this case, the workflow only needs to read repository contents (for actions/checkout), so `contents: read` is sufficient. If in the future the workflow needs to write to pull requests or issues, those permissions can be added. The best place to add this is at the top level of the workflow, just after the `name:` block and before `on:`, so it applies to all jobs unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
